### PR TITLE
Fix id field handling and tests

### DIFF
--- a/pkg/db/mongodb_orm.go
+++ b/pkg/db/mongodb_orm.go
@@ -413,7 +413,7 @@ func (r *MongoORM[T]) getIdValue(document interface{}) (uuid.UUID, error) {
 	}
 	xField := mapper.GetXField(val.Type(), "id")
 	if xField == nil {
-		xField := mapper.GetXField(val.Type(), "ID")
+		xField = mapper.GetXField(val.Type(), "ID")
 		if xField == nil {
 			return uuid.Nil, fmt.Errorf("campo 'ID' não encontrado")
 		}
@@ -433,7 +433,7 @@ func (r *MongoORM[T]) setIdValue(document interface{}, id uuid.UUID) error {
 	}
 	xField := mapper.GetXField(val.Type(), "id")
 	if xField == nil {
-		xField := mapper.GetXField(val.Type(), "ID")
+		xField = mapper.GetXField(val.Type(), "ID")
 		if xField == nil {
 			return fmt.Errorf("campo 'ID' não encontrado")
 		}

--- a/pkg/db/mongodb_orm_test.go
+++ b/pkg/db/mongodb_orm_test.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// Struct with lowercase id field
+type lowerIDStruct struct {
+	id uuid.UUID
+}
+
+// Struct with exported ID field
+type upperIDStruct struct {
+	ID uuid.UUID
+}
+
+// Struct without ID fields
+type noIDStruct struct {
+	Name string
+}
+
+func TestGetIdValue_LowercaseField(t *testing.T) {
+	orm := MongoORM[lowerIDStruct]{}
+	expected := uuid.New()
+	doc := lowerIDStruct{id: expected}
+
+	val, err := orm.getIdValue(&doc)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, val)
+}
+
+func TestGetIdValue_UppercaseField(t *testing.T) {
+	orm := MongoORM[upperIDStruct]{}
+	expected := uuid.New()
+	doc := upperIDStruct{ID: expected}
+
+	val, err := orm.getIdValue(&doc)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, val)
+}
+
+func TestGetIdValue_FieldMissing(t *testing.T) {
+	orm := MongoORM[noIDStruct]{}
+	doc := noIDStruct{Name: "test"}
+
+	val, err := orm.getIdValue(&doc)
+	assert.Error(t, err)
+	assert.Equal(t, uuid.Nil, val)
+}
+
+func TestSetIdValue_LowercaseField(t *testing.T) {
+	orm := MongoORM[lowerIDStruct]{}
+	id := uuid.New()
+	doc := lowerIDStruct{}
+
+	err := orm.setIdValue(&doc, id)
+	assert.NoError(t, err)
+	assert.Equal(t, id, doc.id)
+}
+
+func TestSetIdValue_UppercaseField(t *testing.T) {
+	orm := MongoORM[upperIDStruct]{}
+	id := uuid.New()
+	doc := upperIDStruct{}
+
+	err := orm.setIdValue(&doc, id)
+	assert.NoError(t, err)
+	assert.Equal(t, id, doc.ID)
+}
+
+func TestSetIdValue_FieldMissing(t *testing.T) {
+	orm := MongoORM[noIDStruct]{}
+	id := uuid.New()
+	doc := noIDStruct{}
+
+	err := orm.setIdValue(&doc, id)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- fix variable assignment in getIdValue and setIdValue
- add unit tests for getIdValue and setIdValue

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: go.mod requires go >= 1.24)*