### PR TITLE
Switch to sonic for JSON

### DIFF
--- a/examples/queue_consumer/store.go
+++ b/examples/queue_consumer/store.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
+
+	"github.com/bytedance/sonic"
 	"github.com/caiomarcatti12/nanogo/pkg/log"
 )
 
@@ -21,8 +22,8 @@ func (c *EventConsumer) Handler(event Event, headers map[string]interface{}) err
 		return fmt.Errorf("evento com ID vazio não pode ser processado")
 	}
 
-	// Realiza o marshal do evento usando json.Marshal
-	jsonData, err := json.Marshal(event)
+	// Realiza o marshal do evento usando sonic.Marshal
+	jsonData, err := sonic.Marshal(event)
 	if err != nil {
 		// Log de erro caso o marshal falhe
 		c.logger.Error("Erro ao marshallizar o evento", "error", err)

--- a/go.mod
+++ b/go.mod
@@ -24,9 +24,10 @@ require (
 	github.com/go-playground/validator/v10 v10.20.0
 	github.com/gomodule/redigo v1.9.2
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/mux v1.8.1
-	github.com/gorilla/websocket v1.5.3
-	github.com/joho/godotenv v1.5.1
+        github.com/gorilla/mux v1.8.1
+        github.com/gorilla/websocket v1.5.3
+        github.com/bytedance/sonic v1.10.0
+        github.com/joho/godotenv v1.5.1
 	github.com/jtolds/gls v4.20.0+incompatible
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mozillazg/go-httpheader v0.4.0

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -16,10 +16,11 @@
 package cache
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/bytedance/sonic"
 
 	"github.com/caiomarcatti12/nanogo/pkg/env"
 	"github.com/caiomarcatti12/nanogo/pkg/log"
@@ -93,7 +94,7 @@ func (r *RedisCache) GetDecoded(key string, dest interface{}) error {
 		return err
 	}
 
-	err = json.Unmarshal([]byte(value), &dest)
+	err = sonic.Unmarshal([]byte(value), &dest)
 
 	if err != nil {
 		return fmt.Errorf("error while trying to decode value: %w", err)
@@ -144,7 +145,7 @@ func (r *RedisCache) Disconnect() {
 }
 
 func (r *RedisCache) stringifyValue(value interface{}) (string, error) {
-	bytes, err := json.Marshal(value)
+	bytes, err := sonic.Marshal(value)
 	if err != nil {
 		return "", errors.New("failed to stringify value: " + err.Error())
 	}

--- a/pkg/env/env_aws_loader.go
+++ b/pkg/env/env_aws_loader.go
@@ -16,10 +16,11 @@
 package env
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/bytedance/sonic"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -142,7 +143,7 @@ func (a *AWSLoader) retrieveAndInjectSecrets(creds *credentials.Credentials, reg
 
 func (a *AWSLoader) injectEnvVariables(jsonData string) error {
 	var data map[string]string
-	if err := json.Unmarshal([]byte(jsonData), &data); err != nil {
+	if err := sonic.Unmarshal([]byte(jsonData), &data); err != nil {
 		return fmt.Errorf(a.i18n.Get("aws.json_parse_error", map[string]interface{}{"error": err}))
 	}
 

--- a/pkg/log/logger_adapter.go
+++ b/pkg/log/logger_adapter.go
@@ -16,10 +16,11 @@
 package log
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/bytedance/sonic"
 
 	"github.com/caiomarcatti12/nanogo/pkg/context_manager"
 	"github.com/google/uuid"
@@ -150,9 +151,9 @@ func (l *Logger) extractFields(args ...interface{}) logrus.Fields {
 		case Fields:
 			fields = logrus.Fields(v)
 		default:
-			data, err := json.Marshal(v)
+			data, err := sonic.Marshal(v)
 			if err == nil {
-				_ = json.Unmarshal(data, &fields)
+				_ = sonic.Unmarshal(data, &fields)
 			}
 		}
 	}

--- a/pkg/queue/rabbitmq_provider.go
+++ b/pkg/queue/rabbitmq_provider.go
@@ -16,11 +16,12 @@
 package queue
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
 	"sync"
+
+	"github.com/bytedance/sonic"
 
 	"github.com/caiomarcatti12/nanogo/pkg/context_manager"
 	"github.com/caiomarcatti12/nanogo/pkg/di"
@@ -248,7 +249,7 @@ func (r *Rabbitmq) Publish(exchange string, routingKey string, body interface{})
 
 	r.metricMonitor.IncrementCounter(QueueMessagePublish.String(), map[string]string{"queue": exchange, "routing_key": routingKey})
 
-	bodyBytes, err := json.Marshal(body)
+	bodyBytes, err := sonic.Marshal(body)
 	if err != nil {
 		r.logger.Error(err.Error())
 		return
@@ -509,7 +510,7 @@ func (r *Rabbitmq) callConsumerHandler(consumer interface{}, body []byte, header
 	var result map[string]interface{}
 
 	// Fazer o parse do JSON
-	err = json.Unmarshal(body, &result)
+	err = sonic.Unmarshal(body, &result)
 	if err != nil {
 		fmt.Println("Erro ao fazer unmarshal:", err)
 		return

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -17,9 +17,10 @@ package telemetry
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
 	"time"
+
+	"github.com/bytedance/sonic"
 
 	"github.com/caiomarcatti12/nanogo/pkg/context_manager"
 	"github.com/caiomarcatti12/nanogo/pkg/env"
@@ -187,14 +188,14 @@ func (t *Telemetry) extractAttributesRecursively(attrs map[string]interface{}, p
 			attributes = append(attributes, attribute.String(fullKey, v.(uuid.UUID).String()))
 		default:
 			// Convert to JSON
-			jsonData, err := json.Marshal(v)
+			jsonData, err := sonic.Marshal(v)
 			if err != nil {
 				// Handle error if needed
 				continue
 			}
 			// Convert JSON back to map[string]interface{}
 			var jsonMap map[string]interface{}
-			err = json.Unmarshal(jsonData, &jsonMap)
+			err = sonic.Unmarshal(jsonData, &jsonMap)
 			if err != nil {
 				// Handle error if needed
 				continue

--- a/pkg/websocketserver/websocket_handler.go
+++ b/pkg/websocketserver/websocket_handler.go
@@ -16,10 +16,11 @@
 package websocketserver
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"reflect"
+
+	"github.com/bytedance/sonic"
 
 	"github.com/caiomarcatti12/nanogo/pkg/mapper"
 	"github.com/caiomarcatti12/nanogo/pkg/validator"
@@ -97,7 +98,7 @@ func (wss *WebSocketServer) HandleConnections(w http.ResponseWriter, r *http.Req
 func (wss *WebSocketServer) parseMessage(msg []byte) (Message, error) {
 	var payload Message
 
-	err := json.Unmarshal(msg, &payload)
+	err := sonic.Unmarshal(msg, &payload)
 	if err != nil {
 		return Message{}, err
 	}
@@ -183,7 +184,7 @@ func (wss *WebSocketServer) sendJSONError(clientConnection *websocket.Conn, err 
 }
 
 func (wss *WebSocketServer) sendJSONResponse(clientConnection *websocket.Conn, response interface{}) error {
-	responseBytes, err := json.Marshal(response)
+	responseBytes, err := sonic.Marshal(response)
 
 	if err != nil {
 		return err
@@ -208,7 +209,7 @@ func (wss *WebSocketServer) debugInput(payload Message) {
 	logData["path"] = payload.Path
 	logData["payload"] = payload.payload
 
-	json, _ := json.MarshalIndent(logData, "", "  ")
+	b, _ := sonic.MarshalIndent(logData, "", "  ")
 
-	wss.logger.Trace(string(json))
+	wss.logger.Trace(string(b))
 }


### PR DESCRIPTION
## Summary
- replace `encoding/json` usages with `github.com/bytedance/sonic`
- add sonic module requirement

## Testing
- `go test ./...` *(fails: proxy access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687273b298608323b6868c389f7b2a7a